### PR TITLE
Add another workaround for rspec-puppet testing

### DIFF
--- a/lib/puppet/functions/node_decrypt.rb
+++ b/lib/puppet/functions/node_decrypt.rb
@@ -9,8 +9,13 @@ Puppet::Functions.create_function(:node_decrypt) do
   end
 
   def decrypt(content)
+    decrypted_data = if content.include?('MOCKED_DATA')
+                       'content'
+                     else
+                       Puppet_X::Binford2k::NodeEncrypt.decrypt(content)
+                     end
     Puppet::Pops::Types::PSensitiveType::Sensitive.new(
-      Puppet_X::Binford2k::NodeEncrypt.decrypt(content)
+      decrypted_data
     )
   end
 end


### PR DESCRIPTION
As a follow up to d6c401045103f299ff3cf9cbdeb2ea2abe554f98, (made before I started using Puppet 6), we need to
bypass actual decryption when using onceover and `node_encrypt.secret`.

This is needed because rspec-puppet resolves Deferred functions.
See https://github.com/rodjek/rspec-puppet/pull/743

We also can't just mock this function in onceover, because the normal
way to mock a ruby function is with a puppet language function, but
these do not work with `Deferred`.