### PR TITLE
(CONT-1041) - Add Puppet 8 Support/Drop Puppet 6 Support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -108,7 +108,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.0.0 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ],
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",


### PR DESCRIPTION
This PR adds support for Puppet 8 and Drops support for Puppet 6.

All other required steps to carry out for puppet 8 compatibility already completed in https://github.com/puppetlabs/puppetlabs-node_encrypt/pull/93