### PR TITLE
(CONT-1042) - Remove unsupported OS

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -21,9 +21,6 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "4",
-        "5",
-        "6",
         "7",
         "8",
         "9"
@@ -32,9 +29,6 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "4",
-        "5",
-        "6",
         "7",
         "8"
       ]
@@ -42,26 +36,18 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "4",
-        "5",
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "Scientific",
       "operatingsystemrelease": [
-        "4",
-        "5",
-        "6",
         "7"
       ]
     },
     {
       "operatingsystem": "SLES",
       "operatingsystemrelease": [
-        "10 SP4",
-        "11 SP1",
         "12",
         "15"
       ]
@@ -69,10 +55,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "6",
-        "7",
-        "8",
-        "9",
         "10",
         "11"
       ]
@@ -80,10 +62,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "10.04",
-        "12.04",
-        "14.04",
-        "16.04",
         "18.04",
         "20.04"
       ]
@@ -91,7 +69,6 @@
     {
       "operatingsystem": "Solaris",
       "operatingsystemrelease": [
-        "10",
         "11",
         "12"
       ]
@@ -99,23 +76,17 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "2008",
-        "2008 R2",
         "2012",
         "2012 R2",
         "2016",
         "2019",
         "2022",
-        "7",
-        "8.1",
         "10"
       ]
     },
     {
       "operatingsystem": "AIX",
       "operatingsystemrelease": [
-        "5.3",
-        "6.1",
         "7.1",
         "7.2"
       ]


### PR DESCRIPTION
This PR removes support for:
Redhat - 4, 5, 6
CentOS - 4, 5, 6
Oracle Linux - 4, 5, 6
Scientific - 4, 5, 6
SLES - 10 SP4, 11 SP1
Debian - 6, 7, 8, 9
Ubuntu - 10.04, 12.04, 14.04, 16.04
Solaris - 10
Windows - 2008, 2008 R2, 7, 8.1
AIX - 5.3, 6.1
